### PR TITLE
:lipstick: Add space around boxes

### DIFF
--- a/src/components/bookSection/bookSection.tsx
+++ b/src/components/bookSection/bookSection.tsx
@@ -25,7 +25,7 @@ export const BookSection = (props: Props) => {
   }
 
   return (
-    <div className="px-3 py-2">
+    <div className="px-3 pb-5">
       <div className="box">
         <h2 className="box-title px-2 my-0 py-2 ">{title}</h2>
         <h3 className="box-subtitle px-2">{subTitle}</h3>

--- a/src/components/rightPage/rightPage.tsx
+++ b/src/components/rightPage/rightPage.tsx
@@ -25,7 +25,7 @@ export const RightPage = (props: Props) => {
   }
 
   return (
-    <div className="col-lg-6 col-md-6">
+    <div className="col-lg-6 col-md-6 py-5">
       <div>{listRightPage}</div>
     </div>
   )


### PR DESCRIPTION
Merge resulted in that the title from the BookSection box was going over the book in the LeftPage.  
 - add vertical padding on LeftPage component so space between box and top of left page
Also, add bottom padding in BookSection so there are spaces between all boxes

![image](https://user-images.githubusercontent.com/60652902/94373622-8780f200-00fe-11eb-8091-bd92ff0759eb.png)
