### PR TITLE
Prevent xss

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@types/dompurify": "^2.0.4",
     "@types/enzyme": "^3.10.5",
     "@types/reactstrap": "^8.5.1",
     "bootstrap": "^4.5.0",

--- a/src/templates/chapter.tsx
+++ b/src/templates/chapter.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-
+import dompurify from "dompurify"
 import { Layout } from "../components"
 import { DoublePage } from "../components/index"
 
@@ -15,12 +15,12 @@ interface Data {
 export default function NewChapter(data: Data) {
   const { frontmatter, html } = data.data.markdownRemark
   const { title, leftPage, rightPage } = frontmatter
-
+  const sanitizer = dompurify.sanitize
   return (
     <Layout>
       <DoublePage title={title} leftPage={leftPage} rightPage={rightPage} />
       <div>
-        <div dangerouslySetInnerHTML={{ __html: html }} />
+        <div dangerouslySetInnerHTML={{ __html: sanitizer }} />
       </div>
     </Layout>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,6 +2092,13 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.30.tgz#dc1e40f7af3b9c815013a7860e6252f6352a84df"
   integrity sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==
 
+"@types/dompurify@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.0.4.tgz#25fce15f1f4b1bc0df0ad957040cf226416ac2d7"
+  integrity sha512-y6K7NyXTQvjr8hJNsAFAD8yshCsIJ0d+OYEFzULuIqWyWOKL2hRru1I+rorI5U0K4SLAROTNuSUFXPDTu278YA==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/enzyme@^3.10.5":
   version "3.10.6"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.6.tgz#a34a6b09ff732be29c194dc8d786555f4717fd85"
@@ -2354,6 +2361,11 @@
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
   integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
+
+"@types/trusted-types@*":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
This branch reinstates the use of dompurify to sanitize programmatically set html within chapter.tsx