### PR TITLE
changes navbar titles to one word

### DIFF
--- a/src/content/contact.md
+++ b/src/content/contact.md
@@ -1,5 +1,5 @@
 ---
-title: "Contact Me"
+title: "Contact"
 chapter: "8"
 leftPage:
   - title: Portfolio

--- a/src/content/future.md
+++ b/src/content/future.md
@@ -1,5 +1,5 @@
 ---
-title: "The Future"
+title: "Future"
 chapter: "7"
 leftPage:
   - title: 1 The Future

--- a/src/content/thestart.md
+++ b/src/content/thestart.md
@@ -1,5 +1,5 @@
 ---
-title: "The Start"
+title: "Start"
 chapter: "2"
 leftPage:
   - title: The very start

--- a/src/content/workinglife.md
+++ b/src/content/workinglife.md
@@ -1,5 +1,5 @@
 ---
-title: "Working Life"
+title: "Employment"
 chapter: "3"
 testBody:
   leftPage:


### PR DESCRIPTION
This branch is a temporary fix for responsiveness for the line under the navBar.
Previously some of the links had 2 words when the screen was a medium viewport it the line under the navbar would break as the two words would go on separate lines. This temporarily solves this issue. 