### PR TITLE
Refactor pathname

### DIFF
--- a/src/components/layout/index.spec.tsx
+++ b/src/components/layout/index.spec.tsx
@@ -15,8 +15,6 @@ describe("Layout", () => {
     const navigationContainer = (
       <NavigationContainer chapter="0" slug="x"></NavigationContainer>
     )
-    console.log(wrapper.debug())
-
     expect(wrapper.containsMatchingElement(navigationContainer)).toEqual(true)
   })
 })

--- a/src/components/layout/index.spec.tsx
+++ b/src/components/layout/index.spec.tsx
@@ -17,7 +17,7 @@ describe("Layout", () => {
 
     const wrapper = shallow(
       <Layout
-        pathName="\"
+        slug="\"
         children=""
         listLinks={listLinks}
         frontmatterData={frontMatterData}
@@ -37,14 +37,14 @@ describe("Layout", () => {
     ]
     const wrapper = shallow(
       <Layout
-        pathName="\"
+        slug="\"
         children=""
         listLinks={listLinks}
         frontmatterData={frontMatterData}
       ></Layout>
     )
     const navigationContainer = (
-      <NavigationContainer pathName="\"></NavigationContainer>
+      <NavigationContainer slug="\"></NavigationContainer>
     )
 
     expect(wrapper.containsMatchingElement(navigationContainer)).toEqual(true)

--- a/src/components/layout/index.spec.tsx
+++ b/src/components/layout/index.spec.tsx
@@ -1,50 +1,17 @@
 import React from "react"
-import ReactNode from "react"
+
 import { shallow } from "enzyme"
 import { Layout } from "./index"
 import { NavigationContainer } from "../index"
 
 describe("Layout", () => {
   it("renders a page correctly", () => {
-    const listLinks = ["\\"]
-    const frontMatterData = [
-      {
-        title: "Home",
-        jobTitle: "Junior Developer",
-        greeting: "Hi I'm Joseph Jones",
-      },
-    ]
-
-    const wrapper = shallow(
-      <Layout
-        slug="\"
-        children=""
-        listLinks={listLinks}
-        frontmatterData={frontMatterData}
-        chapter="0"
-      ></Layout>
-    )
+    const wrapper = shallow(<Layout slug="\" children="" chapter="0"></Layout>)
     expect(wrapper).toHaveLength(1)
   })
 
   it("renders the NavigationContainer correctly", () => {
-    const listLinks = ["x"]
-    const frontMatterData = [
-      {
-        title: "Home",
-        jobTitle: "Junior Developer",
-        greeting: "Hi I'm Joseph Jones",
-      },
-    ]
-    const wrapper = shallow(
-      <Layout
-        slug="x"
-        children=""
-        listLinks={listLinks}
-        frontmatterData={frontMatterData}
-        chapter="0"
-      ></Layout>
-    )
+    const wrapper = shallow(<Layout slug="x" children="" chapter="0"></Layout>)
     const navigationContainer = (
       <NavigationContainer chapter="0" slug="x"></NavigationContainer>
     )

--- a/src/components/layout/index.spec.tsx
+++ b/src/components/layout/index.spec.tsx
@@ -21,13 +21,14 @@ describe("Layout", () => {
         children=""
         listLinks={listLinks}
         frontmatterData={frontMatterData}
+        chapter="0"
       ></Layout>
     )
     expect(wrapper).toHaveLength(1)
   })
 
   it("renders the NavigationContainer correctly", () => {
-    const listLinks = ["\\"]
+    const listLinks = ["x"]
     const frontMatterData = [
       {
         title: "Home",
@@ -37,15 +38,17 @@ describe("Layout", () => {
     ]
     const wrapper = shallow(
       <Layout
-        slug="\"
+        slug="x"
         children=""
         listLinks={listLinks}
         frontmatterData={frontMatterData}
+        chapter="0"
       ></Layout>
     )
     const navigationContainer = (
-      <NavigationContainer slug="\"></NavigationContainer>
+      <NavigationContainer chapter="0" slug="x"></NavigationContainer>
     )
+    console.log(wrapper.debug())
 
     expect(wrapper.containsMatchingElement(navigationContainer)).toEqual(true)
   })

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -11,17 +11,17 @@ interface FrontmatterData {
 
 interface Props {
   children: ReactNode
-  pathName: string
+  slug: string
   listLinks: Array<string>
   frontmatterData: Array<FrontmatterData>
 }
 
 const Layout = (props: Props) => {
-  const { children, pathName } = props
+  const { children, slug } = props
 
   return (
     <div>
-      <NavigationContainer pathName={pathName} />
+      <NavigationContainer slug={slug} />
       <main>{children}</main>
     </div>
   )

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -3,18 +3,10 @@ import React, { ReactNode } from "react"
 import { NavigationContainer } from "../index"
 import "./index.scss"
 
-interface FrontmatterData {
-  title: string
-  jobTitle: string
-  greeting: string
-}
-
 interface Props {
   children: ReactNode
   slug: string
   chapter: string
-  listLinks: Array<string>
-  frontmatterData: Array<FrontmatterData>
 }
 
 const Layout = (props: Props) => {

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -12,16 +12,17 @@ interface FrontmatterData {
 interface Props {
   children: ReactNode
   slug: string
+  chapter: string
   listLinks: Array<string>
   frontmatterData: Array<FrontmatterData>
 }
 
 const Layout = (props: Props) => {
-  const { children, slug } = props
+  const { children, slug, chapter } = props
 
   return (
     <div>
-      <NavigationContainer slug={slug} />
+      <NavigationContainer slug={slug} chapter={chapter} />
       <main>{children}</main>
     </div>
   )

--- a/src/components/navBar/navBar.spec.tsx
+++ b/src/components/navBar/navBar.spec.tsx
@@ -17,7 +17,7 @@ describe("NavBar", () => {
       ]
       let wrapper = shallow(
         <NavBar
-          pathName=""
+          slug=""
           listLinks={listLinks}
           frontmatterData={frontMatterData}
         ></NavBar>

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -10,13 +10,13 @@ interface FrontmatterData {
   greeting: string
 }
 interface Props {
-  pathName: string
+  slug: string
   listLinks: Array<string>
   frontmatterData: Array<FrontmatterData>
 }
 
 export const NavBar = (props: Props) => {
-  const { pathName, listLinks, frontmatterData } = props
+  const { slug, listLinks, frontmatterData } = props
 
   var listItems = listLinks.map((link: any, index: number) => (
     <NavBarItem

--- a/src/components/navigationContainer/navigationContainer.tsx
+++ b/src/components/navigationContainer/navigationContainer.tsx
@@ -40,8 +40,6 @@ const NavigationContainer = (props: Props) => {
     }
   `)
 
-  //console.log(layoutData.allMarkdownRemark.edges[chapter])
-
   const listLinks = layoutData.allMarkdownRemark.edges.map(
     ({ node }: { node: any }) => node.fields.slug
   )
@@ -50,10 +48,13 @@ const NavigationContainer = (props: Props) => {
     ({ node }: { node: any }) => node.frontmatter
   )
 
-  const nextLink = layoutData.allMarkdownRemark.edges[chapter].next.fields.slug
+  const next = chapter ? layoutData.allMarkdownRemark.edges[chapter].next : ""
+  const previous = chapter
+    ? layoutData.allMarkdownRemark.edges[chapter].previous
+    : ""
 
-  const previousLink =
-    layoutData.allMarkdownRemark.edges[chapter].previous.fields.slug
+  const nextLink = next ? next.fields.slug : null
+  const previousLink = previous ? previous.fields.slug : null
 
   return (
     <div>
@@ -63,13 +64,7 @@ const NavigationContainer = (props: Props) => {
         frontmatterData={frontmatterData}
       />
       <div className="d-flex justify-content-center">
-        <Pagers
-          slug={slug}
-          listLinks={listLinks}
-          nextLink={nextLink}
-          previousLink={previousLink}
-        />
-        {/* [{next: /2 slug: /1 previous/0}, .... ]  */}
+        <Pagers nextLink={nextLink} previousLink={previousLink} />
       </div>
     </div>
   )

--- a/src/components/navigationContainer/navigationContainer.tsx
+++ b/src/components/navigationContainer/navigationContainer.tsx
@@ -2,17 +2,29 @@ import React from "react"
 import { graphql, useStaticQuery } from "gatsby"
 import { Pagers, NavBar } from "../index"
 import "./navigationContainer.scss"
+
 interface Props {
   slug: string
+  chapter: string
 }
 
 const NavigationContainer = (props: Props) => {
-  const { slug } = props
+  const { slug, chapter } = props
 
   const layoutData = useStaticQuery(graphql`
     {
       allMarkdownRemark(sort: { fields: frontmatter___chapter }) {
         edges {
+          previous {
+            fields {
+              slug
+            }
+          }
+          next {
+            fields {
+              slug
+            }
+          }
           node {
             fields {
               slug
@@ -28,6 +40,8 @@ const NavigationContainer = (props: Props) => {
     }
   `)
 
+  //console.log(layoutData.allMarkdownRemark.edges[chapter])
+
   const listLinks = layoutData.allMarkdownRemark.edges.map(
     ({ node }: { node: any }) => node.fields.slug
   )
@@ -35,6 +49,11 @@ const NavigationContainer = (props: Props) => {
   const frontmatterData = layoutData.allMarkdownRemark.edges.map(
     ({ node }: { node: any }) => node.frontmatter
   )
+
+  const nextLink = layoutData.allMarkdownRemark.edges[chapter].next.fields.slug
+
+  const previousLink =
+    layoutData.allMarkdownRemark.edges[chapter].previous.fields.slug
 
   return (
     <div>
@@ -44,7 +63,13 @@ const NavigationContainer = (props: Props) => {
         frontmatterData={frontmatterData}
       />
       <div className="d-flex justify-content-center">
-        <Pagers slug={slug} listLinks={listLinks} />
+        <Pagers
+          slug={slug}
+          listLinks={listLinks}
+          nextLink={nextLink}
+          previousLink={previousLink}
+        />
+        {/* [{next: /2 slug: /1 previous/0}, .... ]  */}
       </div>
     </div>
   )

--- a/src/components/navigationContainer/navigationContainer.tsx
+++ b/src/components/navigationContainer/navigationContainer.tsx
@@ -3,11 +3,11 @@ import { graphql, useStaticQuery } from "gatsby"
 import { Pagers, NavBar } from "../index"
 import "./navigationContainer.scss"
 interface Props {
-  pathName: string
+  slug: string
 }
 
 const NavigationContainer = (props: Props) => {
-  const { pathName } = props
+  const { slug } = props
 
   const layoutData = useStaticQuery(graphql`
     {
@@ -39,12 +39,12 @@ const NavigationContainer = (props: Props) => {
   return (
     <div>
       <NavBar
-        pathName={pathName}
+        slug={slug}
         listLinks={listLinks}
         frontmatterData={frontmatterData}
       />
       <div className="d-flex justify-content-center">
-        <Pagers pathName={pathName} listLinks={listLinks} />
+        <Pagers slug={slug} listLinks={listLinks} />
       </div>
     </div>
   )

--- a/src/components/navigationContainer/navigationContainer.tsx
+++ b/src/components/navigationContainer/navigationContainer.tsx
@@ -48,13 +48,7 @@ const NavigationContainer = (props: Props) => {
     ({ node }: { node: any }) => node.frontmatter
   )
 
-  const next = chapter ? layoutData.allMarkdownRemark.edges[chapter].next : ""
-  const previous = chapter
-    ? layoutData.allMarkdownRemark.edges[chapter].previous
-    : ""
-
-  const nextLink = next ? next.fields.slug : null
-  const previousLink = previous ? previous.fields.slug : null
+  const { next, previous } = layoutData.allMarkdownRemark.edges[chapter]
 
   return (
     <div>
@@ -64,7 +58,7 @@ const NavigationContainer = (props: Props) => {
         frontmatterData={frontmatterData}
       />
       <div className="d-flex justify-content-center">
-        <Pagers nextLink={nextLink} previousLink={previousLink} />
+        <Pagers next={next} previous={previous} />
       </div>
     </div>
   )

--- a/src/components/pagers/pagers.spec.tsx
+++ b/src/components/pagers/pagers.spec.tsx
@@ -1,0 +1,44 @@
+import React, { Component } from "react"
+import { shallow, mount, render } from "enzyme"
+import { Pagers, PreviousPageLink, NextPageLink } from "../index"
+
+describe("Pagers", () => {
+  it("if previous page prop is null it only renders next", () => {
+    const next = { fields: { slug: "/next/" } }
+    const previous = null
+    const nextPage = <NextPageLink nextLink="/next/" />
+    const prevPage = <PreviousPageLink previousLink="/previous/" />
+    const wrapper = shallow(<Pagers next={next} previous={previous} />)
+    expect(wrapper.containsMatchingElement(nextPage)).toEqual(true)
+    expect(wrapper.containsMatchingElement(prevPage)).toEqual(false)
+  })
+
+  it("if next page prop is null it only renders previous", () => {
+    const next = null
+    const previous = { fields: { slug: "/previous/" } }
+    const nextPage = <NextPageLink nextLink="/next/" />
+    const prevPage = <PreviousPageLink previousLink="/previous/" />
+    const wrapper = shallow(<Pagers next={next} previous={previous} />)
+    expect(wrapper.containsMatchingElement(nextPage)).toEqual(false)
+    expect(wrapper.containsMatchingElement(prevPage)).toEqual(true)
+  })
+  it("if next & previous page props are null it doesn't renders pagelinks", () => {
+    const next = null
+    const previous = null
+    const nextPage = <NextPageLink nextLink="/next/" />
+    const prevPage = <PreviousPageLink previousLink="/previous/" />
+    const wrapper = shallow(<Pagers next={next} previous={previous} />)
+    expect(wrapper.containsMatchingElement(nextPage)).toEqual(false)
+    expect(wrapper.containsMatchingElement(prevPage)).toEqual(false)
+  })
+
+  it("if next & previous page props are defined it renders both", () => {
+    const next = { fields: { slug: "/next/" } }
+    const previous = { fields: { slug: "/previous/" } }
+    const nextPage = <NextPageLink nextLink="/next/" />
+    const prevPage = <PreviousPageLink previousLink="/previous/" />
+    const wrapper = shallow(<Pagers next={next} previous={previous} />)
+    expect(wrapper.containsMatchingElement(nextPage)).toEqual(true)
+    expect(wrapper.containsMatchingElement(prevPage)).toEqual(true)
+  })
+})

--- a/src/components/pagers/pagers.tsx
+++ b/src/components/pagers/pagers.tsx
@@ -15,9 +15,9 @@ export const Pagers = (props: Props) => {
 
   var previousLink: string = listLinks[listLinks.indexOf(slug) - 1]
 
-  if (slug == "/") {
+  if (slug === listLinks[0]) {
     return <NextPageLink nextLink={nextLink} homePage={true} />
-  } else if (slug == "/contact/") {
+  } else if (slug === listLinks[-1]) {
     return <PreviousPageLink lastPage={true} previousLink={previousLink} />
   } else {
     return (

--- a/src/components/pagers/pagers.tsx
+++ b/src/components/pagers/pagers.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Link } from "gatsby"
 
 import { PreviousPageLink, NextPageLink } from "../index"
 
@@ -9,11 +8,12 @@ interface Props {
 }
 
 export const Pagers = (props: Props) => {
-  const { slug, listLinks } = props
+  const { slug, listLinks, nextLink, previousLink } = props
+  console.log(nextLink, previousLink)
 
-  var nextLink: string = listLinks[listLinks.indexOf(slug) + 1]
+  // var nextLink: string = listLinks[listLinks.indexOf(slug) + 1]
 
-  var previousLink: string = listLinks[listLinks.indexOf(slug) - 1]
+  // var previousLink: string = listLinks[listLinks.indexOf(slug) - 1]
 
   if (slug === listLinks[0]) {
     return <NextPageLink nextLink={nextLink} homePage={true} />

--- a/src/components/pagers/pagers.tsx
+++ b/src/components/pagers/pagers.tsx
@@ -4,26 +4,20 @@ import { Link } from "gatsby"
 import { PreviousPageLink, NextPageLink } from "../index"
 
 interface Props {
-  pathName: string
+  slug: string
   listLinks: Array<string>
 }
 
 export const Pagers = (props: Props) => {
-  const { pathName, listLinks } = props
+  const { slug, listLinks } = props
 
-  var nextLink: string =
-    typeof window !== "undefined"
-      ? listLinks[listLinks.indexOf(pathName) + 1]
-      : ""
+  var nextLink: string = listLinks[listLinks.indexOf(slug) + 1]
 
-  var previousLink: string =
-    typeof window !== "undefined"
-      ? listLinks[listLinks.indexOf(pathName) - 1]
-      : ""
+  var previousLink: string = listLinks[listLinks.indexOf(slug) - 1]
 
-  if (pathName == "/") {
+  if (slug == "/") {
     return <NextPageLink nextLink={nextLink} homePage={true} />
-  } else if (pathName == "/contact/") {
+  } else if (slug == "/contact/") {
     return <PreviousPageLink lastPage={true} previousLink={previousLink} />
   } else {
     return (

--- a/src/components/pagers/pagers.tsx
+++ b/src/components/pagers/pagers.tsx
@@ -3,21 +3,16 @@ import React from "react"
 import { PreviousPageLink, NextPageLink } from "../index"
 
 interface Props {
-  slug: string
-  listLinks: Array<string>
+  nextLink: string
+  previousLink: string
 }
 
 export const Pagers = (props: Props) => {
-  const { slug, listLinks, nextLink, previousLink } = props
-  console.log(nextLink, previousLink)
+  const { nextLink, previousLink } = props
 
-  // var nextLink: string = listLinks[listLinks.indexOf(slug) + 1]
-
-  // var previousLink: string = listLinks[listLinks.indexOf(slug) - 1]
-
-  if (slug === listLinks[0]) {
+  if (!previousLink) {
     return <NextPageLink nextLink={nextLink} homePage={true} />
-  } else if (slug === listLinks[-1]) {
+  } else if (!nextLink) {
     return <PreviousPageLink lastPage={true} previousLink={previousLink} />
   } else {
     return (

--- a/src/components/pagers/pagers.tsx
+++ b/src/components/pagers/pagers.tsx
@@ -2,25 +2,23 @@ import React from "react"
 
 import { PreviousPageLink, NextPageLink } from "../index"
 
+interface Direction {
+  fields: { slug: string }
+}
+
 interface Props {
-  nextLink: string
-  previousLink: string
+  next: Direction | null
+  previous: Direction | null
 }
 
 export const Pagers = (props: Props) => {
-  const { nextLink, previousLink } = props
+  const { next, previous } = props
 
-  if (!previousLink) {
-    return <NextPageLink nextLink={nextLink} homePage={true} />
-  } else if (!nextLink) {
-    return <PreviousPageLink lastPage={true} previousLink={previousLink} />
-  } else {
-    return (
-      <>
-        <PreviousPageLink previousLink={previousLink} />
-        <div>&nbsp;&nbsp;</div>
-        <NextPageLink nextLink={nextLink} />
-      </>
-    )
-  }
+  return (
+    <>
+      {previous && <PreviousPageLink previousLink={previous.fields.slug} />}
+      <div>&nbsp;&nbsp;</div>
+      {next && <NextPageLink nextLink={next.fields.slug} />}
+    </>
+  )
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,12 +1,18 @@
 import React from "react"
-
 import { SEO } from "../components"
 
 const NotFoundPage = () => (
   <>
     <SEO title="404: Not found" />
-    <h1>NOT FOUND</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    <div className="d-flex align-items-center flex-column">
+      <h1>NOT FOUND</h1>
+      <img
+        src="https://www.ikea.com/gb/en/images/products/billy-bookcase-white__0625599_PE692385_S5.JPG?f=xl "
+        style={{ maxWidth: "40%" }}
+        alt="bookcase_404"
+      />
+      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    </div>
   </>
 )
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 
-import { Layout, SEO } from "../components"
+import { SEO } from "../components"
 
 const NotFoundPage = () => (
-  <Layout>
+  <>
     <SEO title="404: Not found" />
     <h1>NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-  </Layout>
+  </>
 )
 
 export default NotFoundPage

--- a/src/templates/chapter.tsx
+++ b/src/templates/chapter.tsx
@@ -8,7 +8,7 @@ interface dataItem {
   body: object
 }
 interface Link {
-  pathname: string
+  slug: string
 }
 interface Props {
   data: dataItem
@@ -16,12 +16,12 @@ interface Props {
 }
 
 const NewChapter = (props: Props) => {
-  const { location, data } = props
-  const { pathname } = location
+  const { data } = props
   const { frontmatter } = data.markdownRemark
+  const { slug } = data.markdownRemark.fields
   const { title, leftPage, rightPage } = frontmatter
   return (
-    <Layout pathName={pathname}>
+    <Layout slug={slug}>
       <DoublePage title={title} leftPage={leftPage} rightPage={rightPage} />
     </Layout>
   )
@@ -31,6 +31,9 @@ export const query = graphql`
   query($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
+      fields {
+        slug
+      }
       frontmatter {
         title
         leftPage {

--- a/src/templates/chapter.tsx
+++ b/src/templates/chapter.tsx
@@ -7,21 +7,20 @@ interface dataItem {
   title: string
   body: object
 }
-interface Link {
-  slug: string
-}
+
 interface Props {
   data: dataItem
-  location: Link
+  slug: string
 }
 
 const NewChapter = (props: Props) => {
   const { data } = props
   const { frontmatter } = data.markdownRemark
   const { slug } = data.markdownRemark.fields
-  const { title, leftPage, rightPage } = frontmatter
+  const { title, leftPage, rightPage, chapter } = frontmatter
+
   return (
-    <Layout slug={slug}>
+    <Layout slug={slug} chapter={chapter}>
       <DoublePage title={title} leftPage={leftPage} rightPage={rightPage} />
     </Layout>
   )
@@ -35,6 +34,7 @@ export const query = graphql`
         slug
       }
       frontmatter {
+        chapter
         title
         leftPage {
           title

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -10,12 +10,12 @@ interface Props {
 }
 
 interface Link {
-  pathname: string
+  slug: string
 }
 
 const IndexPage = (props: Props) => {
-  const { location, data } = props
-  const { pathname } = location
+  const { data } = props
+  const { slug } = data.allMarkdownRemark.edges[0].node.fields
   const {
     jobTitle,
     greeting,
@@ -24,7 +24,7 @@ const IndexPage = (props: Props) => {
   } = data.allMarkdownRemark.edges[0].node.frontmatter
 
   return (
-    <Layout pathName={pathname}>
+    <Layout slug={slug}>
       <SEO title="Home" />
       <BookFrontCover
         jobTitle={jobTitle}
@@ -40,6 +40,9 @@ export const query = graphql`
     allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/index/" } }) {
       edges {
         node {
+          fields {
+            slug
+          }
           frontmatter {
             jobTitle
             greeting

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -17,6 +17,7 @@ const IndexPage = (props: Props) => {
   const { data } = props
   const { slug } = data.allMarkdownRemark.edges[0].node.fields
   const {
+    chapter,
     jobTitle,
     greeting,
     careerAim,
@@ -24,7 +25,7 @@ const IndexPage = (props: Props) => {
   } = data.allMarkdownRemark.edges[0].node.frontmatter
 
   return (
-    <Layout slug={slug}>
+    <Layout slug={slug} chapter={chapter}>
       <SEO title="Home" />
       <BookFrontCover
         jobTitle={jobTitle}
@@ -44,6 +45,7 @@ export const query = graphql`
             slug
           }
           frontmatter {
+            chapter
             jobTitle
             greeting
             careerAim


### PR DESCRIPTION
This branch refactors the generation of the following:

slug (nee pathName)
nextLink
previousLink 

slug is now generated via the template graphQL queries of chapter and index removing the need to use location.pathname.

nextLink and previousLink are now generated via 'previous' and 'next' graphQL queries in the navigationContainer component, replacing the need to use listLinks in the pagers component.